### PR TITLE
Ensure instructions on 'gpu' tag and updated engine

### DIFF
--- a/doc/faq_use_gpu_on_slurm_cluster.md
+++ b/doc/faq_use_gpu_on_slurm_cluster.md
@@ -96,6 +96,10 @@ With the rest of the workflow configured, adding a `gpu` tag (in addition to the
 `hpc` tag) to the launch of the gear will schedule a GPU to execute the gear on the
 Slurm cluster.
 
+Note: If your site already uses the `gpu` tag for launching another engine on Flywheel
+and those jobs are not routed through the HPC Hold engine, please contact Flywheel
+staff.
+
 ### Potential Problems
 
 - Without the `gpu` tag present on gear launch any node meeting the criteria will be

--- a/doc/faq_use_gpu_on_slurm_cluster.md
+++ b/doc/faq_use_gpu_on_slurm_cluster.md
@@ -5,6 +5,7 @@
     - [slurm.conf](#slurmconf)
     - [gres.conf](#gresconf)
   - [Updating the fw-cast settings](#updating-the-fw-cast-settings)
+  - [Compute Engine](#compute-engine)
 - [Gear Execution](#gear-execution)
   - [Potential Problems](#potential-problems)
 
@@ -80,6 +81,14 @@ shown below.
    set -x
    srun ./engine run --single-job {{job.fw_id}}
 ```
+
+### Compute Engine
+
+Ensure that you have a Compute Engine installed that has been compiled after 2024-02-01.
+Please contact Flywheel staff to get an updated Flywheel engine.
+
+After receiving the updated Flywheel engine, install it as per the instructions found
+[here](faq_updating_flywheel_engine.md).
 
 ## Gear Execution
 


### PR DESCRIPTION
The GPU Documentation ensures directions exist for:

- updating the engine to one that detects a GPU
- A `gpu` tag is required to request a GPU from the Slurm scheduler
  - this is in addition to the `hpc` tag necessary to route to the hpc-client.